### PR TITLE
[EVNT-498] Next button always enabled by default

### DIFF
--- a/app/redhat_insights/appserver/static/javascript/views/app.js
+++ b/app/redhat_insights/appserver/static/javascript/views/app.js
@@ -311,7 +311,7 @@ define(["react", "splunkjs/splunk", "splunkjs/mvc"], function (react, splunk_js_
       ]),
       e('button', {
         class: 'btn btn-primary next-button', 'aria-disabled': 'false',
-        disabled: (step === 1 && (isHecCopied || isUrlCopied) ? '' : 'disabled'),
+        disabled: false,
         style: { display: 'inline-block' },
         onClick: handleSetupIntegration
       }, [


### PR DESCRIPTION
"Next: Configure Splunk integration in Insights" button in step 2 shouldn't be disabled. The user probably doesn't remember what they copied and they come back to Splunk anyway.

Preview:

![image](https://user-images.githubusercontent.com/2904206/171042241-1f73eed0-3d3d-4a26-9874-c456417e4cbd.png)
