### PR TITLE
[EVNT-521] - Change 'Old/>30days' to 'Total/Last 30 days' in Dashboard

### DIFF
--- a/app/redhat_insights/default/data/ui/views/main_dashboard.xml
+++ b/app/redhat_insights/default/data/ui/views/main_dashboard.xml
@@ -82,14 +82,14 @@
 		"viz_m20WVFsT": {
 			"type": "viz.text",
 			"options": {
-				"content": ">30 days",
+				"content": "Last 30 days",
 				"fontSize": 12
 			}
 		},
 		"viz_IRvJaQrP": {
 			"type": "viz.text",
 			"options": {
-				"content": "Old",
+				"content": "Total",
 				"fontSize": 16
 			}
 		},
@@ -558,7 +558,7 @@
 		"ds_HRRsnn9w": {
 			"type": "ds.search",
 			"options": {
-				"query": "index=redhatinsights AND event_type=new-recommendation\n  | spath \n  | spath path=events{} output=events\n  | stats by _time, events, application, event_type, account_id, context.display_name\n  | mvexpand events \n  | eval _raw=events\n  | kv\n  | eval risk='payload.total_risk'\n  | table _time, risk\n  | where now()>relative_time(_time, \"+30d\")\n  | where risk=4\n  | timechart span=24h count(risk) as count\n  | appendpipe [| stats count | where count=0 | addinfo | eval time=info_min_time.\" \".info_max_time | makemv time | mvexpand time | table time count | rename time as _time ]"
+				"query": "index=redhatinsights AND event_type=new-recommendation\n  | spath \n  | spath path=events{} output=events\n  | stats by _time, events, application, event_type, account_id, context.display_name\n  | mvexpand events \n  | eval _raw=events\n  | kv\n  | eval risk='payload.total_risk'\n  | table _time, risk\n  | where relative_time(now(), \"-30d\") <= _time\n  | where risk=4\n  | timechart span=24h count(risk) as count\n  | appendpipe [| stats count | where count=0 | addinfo | eval time=info_min_time.\" \".info_max_time | makemv time | mvexpand time | table time count | rename time as _time ]"
 			},
 			"name": "search_critical_recomm_30days"
 		},
@@ -598,7 +598,7 @@
 		"ds_8HzUA9oC_ds_HRRsnn9w": {
 			"type": "ds.search",
 			"options": {
-				"query": "index=redhatinsights AND event_type=new-recommendation\n  | spath \n  | spath path=events{} output=events\n  | stats by _time, events, application, event_type, account_id, context.display_name\n  | mvexpand events \n  | eval _raw=events\n  | kv\n  | eval has_incident='payload.has_incident'\n  | table _time, has_incident\n  | where now()>relative_time(_time, \"+30d\")\n  | where has_incident=\"false\"\n  | timechart span=24h count\n  | appendpipe [| stats count | where count=0 | addinfo | eval time=info_min_time.\" \".info_max_time | makemv time | mvexpand time | table time count | rename time as _time ]"
+				"query": "index=redhatinsights AND event_type=new-recommendation\n  | spath \n  | spath path=events{} output=events\n  | stats by _time, events, application, event_type, account_id, context.display_name\n  | mvexpand events \n  | eval _raw=events\n  | kv\n  | eval has_incident='payload.has_incident'\n  | table _time, has_incident\n  | where relative_time(now(), \"-30d\") <= _time\n  | where has_incident=\"false\"\n  | timechart span=24h count\n  | appendpipe [| stats count | where count=0 | addinfo | eval time=info_min_time.\" \".info_max_time | makemv time | mvexpand time | table time count | rename time as _time ]"
 			},
 			"name": "search_recomm_with_incidents_30days"
 		},


### PR DESCRIPTION
Dashboard for Operations provides the number of events older than 30 days, as well as the number of events in the last 24 hours. A more useful total would be the number of events in the last 30 days. Query and Label need to be changed.

![image](https://user-images.githubusercontent.com/2904206/172420859-f9fc7674-286e-4d16-87fe-8b75825ec565.png)