### PR TITLE
[EVNT-553] Change default timestamp on Event

### DIFF
--- a/app/redhat_insights/default/data/ui/views/events.xml
+++ b/app/redhat_insights/default/data/ui/views/events.xml
@@ -32,8 +32,8 @@ index=redhatinsights AND bundle = "rhel"
     <input type="time" token="timepicker">
       <label>Timestamp</label>
       <default>
-        <earliest></earliest>
-        <latest></latest>
+        <earliest>-24h@h</earliest>
+        <latest>now</latest>
       </default>
     </input>
     <input type="multiselect" token="field_account" searchWhenChanged="true">


### PR DESCRIPTION
Changing default timestamp on Event table to Last 24 hours


Preview:
![image](https://user-images.githubusercontent.com/2904206/173581968-7e3658b1-5104-47fc-a3e0-931537307bd0.png)
