### PR TITLE
[EVNT-554] Change Contact us hyperlink

### DIFF
--- a/app/redhat_insights/default/data/ui/views/contact_us.xml
+++ b/app/redhat_insights/default/data/ui/views/contact_us.xml
@@ -23,7 +23,7 @@
                     </div>
                     <div class="div-container">
                         <h2>Documentation</h2>
-                        <p><a href="https://splunkbase.splunk.com/" target="_blank">Splunk Marketplace documentation <i class="icon-external"/></a></p>
+                        <p><a href="https://splunkbase.splunk.com/app/6439/" target="_blank">Red Hat Insight on Splunkbase Marketplace <i class="icon-external"/></a></p>
                         <p><a href="https://access.redhat.com/documentation/en-us/red_hat_insights/" target="_blank">Red Hat Insights documentation <i class="icon-external"/></a></p>
                         <p><a href="https://www.redhat.com/en/technologies/management/insights/data-application-security" target="_blank">Red Hat Insights data and application security <i class="icon-external"/></a></p>
                     </div>


### PR DESCRIPTION
The hyperlink behind `Splunk Marketplace documentation` points to the top-level Splunkbase Marketplace in `Contact us`. Rename link  to `Red Hat Insight on Splunkbase Marketplace` and point to the application URL.

**Friendly reminder: The app link will work only after the app been published**